### PR TITLE
Wallet Saving for Payment Gate

### DIFF
--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -533,6 +533,8 @@ std::error_code WalletService::createAddress(const std::string& spendSecretKeyTe
     System::EventLock lk(readyEvent);
 
     logger(Logging::DEBUGGING) << "Creating address";
+    
+    saveWallet();
 
     Crypto::SecretKey secretKey;
     if (!Common::podFromHex(spendSecretKeyText, secretKey)) {
@@ -556,6 +558,8 @@ std::error_code WalletService::createAddress(std::string& address) {
     System::EventLock lk(readyEvent);
 
     logger(Logging::DEBUGGING) << "Creating address";
+    
+    saveWallet();
 
     address = wallet.createAddress();
   } catch (std::system_error& x) {
@@ -861,6 +865,8 @@ std::error_code WalletService::sendTransaction(const SendTransaction::Request& r
 
     size_t transactionId = wallet.transfer(sendParams);
     transactionHash = Common::podToHex(wallet.getTransaction(transactionId).hash);
+    
+    saveWallet();
 
     logger(Logging::DEBUGGING) << "Transaction " << transactionHash << " has been sent";
   } catch (std::system_error& x) {


### PR DESCRIPTION
There's a bug associated with the Payment Gate, where if the wallet crashes, none of the addresses save.